### PR TITLE
ENTESB-11200 - set back version on the top level module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   <groupId>io.fabric8</groupId>
   <artifactId>fabric8-maven-plugin-build</artifactId>
   <packaging>pom</packaging>
+  <version>3.5.33-SNAPSHOT</version>
 
   <parent>
     <groupId>io.fabric8</groupId>


### PR DESCRIPTION
otherwise the release pipeline cannot set a specific version

Signed-off-by: Aurélien Pupier <apupier@redhat.com>