### PR TITLE
Merge changes over from 3.5.33 product branch

### DIFF
--- a/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
+++ b/generator/api/src/main/java/io/fabric8/maven/generator/api/FromSelector.java
@@ -68,16 +68,17 @@ public abstract class FromSelector {
     public boolean isRedHat() {
         MavenProject project = context.getProject();
         Plugin plugin = project.getPlugin("io.fabric8:fabric8-maven-plugin");
-        if (plugin == null) {
-            // This plugin might be repackaged.
-            plugin = project.getPlugin("org.jboss.redhat-fuse:fabric8-maven-plugin");
+        if (plugin != null) {
+            String version = plugin.getVersion();
+            return REDHAT_VERSION_PATTERN.matcher(version).matches();
         }
-        if (plugin == null) {
-            // Can happen if not configured in a build section but only in a dependency management section
-            return false;
+        plugin = project.getPlugin("org.jboss.redhat-fuse:fabric8-maven-plugin");
+        if (plugin != null) {
+            // This plugin was repacked in the https://github.com/jboss-fuse/redhat-fuse project
+            return true;
         }
-        String version = plugin.getVersion();
-        return REDHAT_VERSION_PATTERN.matcher(version).matches();
+        // Can happen if not configured in a build section but only in a dependency management section
+        return false;
     }
 
     public static class Default extends FromSelector {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -137,16 +137,6 @@
   </repositories>
 
   <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
   </distributionManagement>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,17 @@
 
   <name>Fabric8 Maven :: Build</name>
 
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <prerequisites>
+    <maven>3.0.3</maven>
+  </prerequisites>
 
   <modules>
     <module>parent</module>


### PR DESCRIPTION

Merging over changes from 3.5.x, it doesn't appear that https://github.com/jboss-fuse/fabric8-maven-plugin/commit/600da787d6d593937626030ce945f5e8cb62d56c was in the 3.5.42 tag.    I'm assuming we need this for sb2, which is going to use a 3.5.42.redhat-7-x branch for f-m-p?