### PR TITLE
Backport of upstream Fix #1755: Spring boot enricher does not pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ We use semantic versioning in some slight variation until our feature set has st
 
 After this we will switch probably to real [Semantic Versioning 2.0.0](http://semver.org/)
 
+###3.5.43-SNAPSHOT
+* Fix #1755: Spring boot enricher does not produce a proper heath check and liveness check path when "/" is used.
+
 ###3.5.42 (2018-10-18)
 * Fix 1346: karaf-maven-plugin is detected under any groupId
 * Fix 1021: Avoids empty deployment selector value in generated yaml resource

--- a/core/src/main/java/io/fabric8/maven/core/util/SpringBootConfigurationHelper.java
+++ b/core/src/main/java/io/fabric8/maven/core/util/SpringBootConfigurationHelper.java
@@ -42,7 +42,7 @@ public class SpringBootConfigurationHelper {
     private static final String[] SERVLET_PATH = {"server.servlet-path", "server.servlet.path"};
     private static final String[] SERVER_CONTEXT_PATH = {"server.context-path", "server.servlet.context-path"};
     private static final String[] MANAGEMENT_CONTEXT_PATH = {"management.context-path", "management.server.servlet.context-path"};
-    private static final String[] ACTUATOR_BASE_PATH = {null, "management.endpoints.web.base-path"};
+    private static final String[] ACTUATOR_BASE_PATH = {"", "management.endpoints.web.base-path"};
     private static final String[] ACTUATOR_DEFAULT_BASE_PATH = {"", "/actuator"};
 
     private int propertyOffset;

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java
@@ -118,7 +118,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
         // lets default to adding a spring boot actuator health check
         ProbeBuilder probeBuilder = new ProbeBuilder().
-                withNewHttpGet().withNewPort(port).withPath(prefix + actuatorBasePath + "/health").withScheme(scheme).endHttpGet();
+                withNewHttpGet().withNewPort(port).withPath(normalizeMultipleSlashes(prefix + actuatorBasePath + "/health")).withScheme(scheme).endHttpGet();
 
         if (initialDelay != null) {
             probeBuilder = probeBuilder.withInitialDelaySeconds(initialDelay);
@@ -133,4 +133,8 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
         return probeBuilder.build();
     }
 
+    private String normalizeMultipleSlashes(String s) {
+        //substitute multiple consecutive "/" with a single occurrence (i.e. ////a//b///c////////d -> /a/b/c/d)
+        return s.replaceAll("/{2,}","/");
+    }
 }

--- a/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
+++ b/enricher/fabric8/src/test/java/io/fabric8/maven/enricher/fabric8/AbstractSpringBootHealthCheckEnricherSupport.java
@@ -112,6 +112,38 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
     }
 
     @Test
+    public void testWithServerPortAndManagementPortAndServerContextPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p2");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/p2" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementPortAndServerContextPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
+        assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
     public void testWithServerPortAndManagementPortAndManagementContextPath() {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         Properties props = new Properties();
@@ -124,6 +156,40 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
+        assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementPortAndManagementContextPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p2");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p3");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/p2/p3" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementPortAndManagementContextPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
         assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
     }
 
@@ -145,6 +211,42 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
     }
 
     @Test
+    public void testWithServerPortAndManagementPortAndManagementContextPathAndServletPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p2");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p3");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/p2/p3" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementPortAndManagementContextPathAndServletPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementPortPropertyKey(), "8383");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
+        assertEquals(8383, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
     public void testWithServerPortAndManagementContextPath() {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         Properties props = new Properties();
@@ -155,6 +257,36 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p1" + propertyHelper.getActuatorDefaultBasePath() +"/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementContextPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p2");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/p1/p2" +"/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementContextPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
         assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
     }
 
@@ -174,6 +306,38 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
     }
 
     @Test
+    public void testWithServerPortAndServerContextPathAndManagementContextPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p2");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p3");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/p2/p1/p3" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndServerContextPathAndManagementContextPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
     public void testWithServerPortAndServletPath() {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         Properties props = new Properties();
@@ -184,6 +348,36 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/servlet" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndServletAndActuatorDefaultBasePathPath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p1");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/servlet/p1" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndServletPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
         assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
     }
 
@@ -203,6 +397,38 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
     }
 
     @Test
+    public void testWithServerPortAndManagementContextPathAndServletPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p2");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/servlet/p1/p2" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndManagementContextPathAndServletPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
     public void testWithServerPortAndServerContextPathAndManagementContextPathAndServletPath() {
         SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
         Properties props = new Properties();
@@ -215,6 +441,40 @@ public abstract class AbstractSpringBootHealthCheckEnricherSupport {
         assertNotNull(probe);
         assertNotNull(probe.getHttpGet());
         assertEquals("/p2/servlet/p1" + propertyHelper.getActuatorDefaultBasePath() + "/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndServerContextPathAndManagementContextPathAndServletPathAndActuatorDefaultBasePath() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/servlet");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/p1");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/p2");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/p3");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/p2/servlet/p1/p3" + "/health", probe.getHttpGet().getPath());
+        assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
+    }
+
+    @Test
+    public void testWithServerPortAndServerContextPathAndManagementContextPathAndServletPathAndActuatorDefaultBasePathSlash() {
+        SpringBootHealthCheckEnricher enricher = new SpringBootHealthCheckEnricher(context);
+        Properties props = new Properties();
+        props.put(propertyHelper.getServerPortPropertyKey(), "8282");
+        props.put(propertyHelper.getServletPathPropertyKey(), "/");
+        props.put(propertyHelper.getManagementContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getServerContextPathPropertyKey(), "/");
+        props.put(propertyHelper.getActuatorBasePathPropertyKey(), "/");
+
+        Probe probe = enricher.buildProbe(props, 10, null, null, 3, 1);
+        assertNotNull(probe);
+        assertNotNull(probe.getHttpGet());
+        assertEquals("/health", probe.getHttpGet().getPath());
         assertEquals(8282, probe.getHttpGet().getPort().getIntVal().intValue());
     }
 


### PR DESCRIPTION
… a proper heath check and liveness check path when / is used.

Conflicts were:
	CHANGELOG.md
	enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/SpringBootHealthCheckEnricher.java