### PR TITLE
[ENTESB-14400] Provide metering labels for Fuse on Openshift (FMP)

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/config/MetaDataConfig.java
+++ b/core/src/main/java/io/fabric8/maven/core/config/MetaDataConfig.java
@@ -86,4 +86,8 @@ public class MetaDataConfig {
     public Properties getIngress() {
         return ingress;
     }
+
+    public void setPod(Properties pod) {
+        this.pod = pod;
+    }
 }

--- a/plugin/src/main/resources/pod-labels.properties
+++ b/plugin/src/main/resources/pod-labels.properties
@@ -1,0 +1,5 @@
+com.company=Red_Hat
+rht.prod_name=Red_Hat_Integration
+rht.prod_ver=7.8
+rht.comp=${project.artifactId}
+rht.comp_ver=${project.version}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14400

All quickstart (fabric8-quickstarts/*) pods should have new Red Hat related labels assigned.