### PR TITLE
[ENTESB-15034] Missing labels on Openshift Service Object in FMP quickstart spring-boot-camel-rest-3scale

### DIFF
--- a/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -958,6 +958,110 @@ This information will be enriched as annotations in the generated manifest like,
 ...
 ----
 
+
+[[f8-service discovery]]
+==== f8-service-discovery
+
+This enricher can be used to add service annotations to facilitate automated discovery of 
+the service by 3scale for Camel RestDSL projects. Other project types may follow at a later time.
+The enricher extracts the needed information from the camel-context.xml, and the restConfiguration element in particular.
+
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring       http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <restConfiguration component="servlet" scheme="https"
+              contextPath="myapi" apiContextPath="myapi/openapi.json"/>
+...
+
+-----
+The enricher looks for the `scheme`, `contextPath` and `apiContextPath` attributes, and it will add the following
+label and annotations:
+
+LABEL
+    discovery.3scale.net/discoverable. The value of the label can be set to "true" or "false", and was added to take part in the selector definition executed by 3scale to find all services that need discovery. Also it can act as a switch as well, to temporary turn off 3scale discovery integration by setting it to "false".
+
+ANNOTATIONS
+    discovery.3scale.net/discovery-version: the version of the 3scale discovery process.
+    discovery.3scale.net/scheme: this can be "http" or "https"
+    discovery.3scale.net/path: (optional) the contextPath of the service if it's not at the root.
+    discovery.3scale.net/description-path: (optional) the path to the service description document (OpenAPI/Swagger). The path can either be relative or an external full URL.
+
+The following configuration parameters can be used to override the behavior of this enricher:
+
+[[enricher-f8-service-discovery]]
+.Fabric8 service discovery enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *springDir*
+| Path to the spring configuration directory where the `camel-context.xml` file lives.
+| `/src/main/resources/spring` which is used to recognize a Camel RestDSL project.
+
+| *scheme*
+| The `scheme` part of the URL where the service is hosted.
+| `http`
+
+| *path*
+| The `path` part of the URL where the service is hosted.
+| `/`
+
+| *descriptionPath*
+| The path to a location where the service description document is hosted. This path can be either a relative path if the document is self-hosted, or a full URL if the document is hosted externally.
+|
+
+| *discoveryVersion*
+| The version of the 3scale discovery implementation.
+| `v1`
+
+| *discoverable*
+| Sets the discoverable label to either true or false. If it's set to "false" 3scale will not try to discover this service.
+| `true`
+
+|===
+
+You specify the properties like for any enricher within the enrichers configuration like in
+
+.Example
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+-----
+<configuration>
+  ..
+  <enricher>
+    <config>
+      <f8-service-discovery>
+        <scheme>https</scheme>
+        <path>/api</path>
+        <descriptionPath>/api/openapi.json</descriptionPath>
+      </f8-service-discovery>
+    </config>
+  </enricher>
+</configuration>
+-----
+
+Alternatively you can us a `src/main/fabric8/service.yml` fragment to override the values. For example
+-----
+kind: Service
+name:
+metadata:
+  labels:
+    discovery.3scale.net/discoverable : "true"
+  annotations:
+    discovery.3scale.net/discovery-version : "v1"
+    discovery.3scale.net/scheme : "https"
+    discovery.3scale.net/path : "/api"
+    discovery.3scale.net/description-path : "/api/openapi.json"
+spec:
+  type: LoadBalancer
+-----
+
+
 [[fmp-revision-history-enricher]]
 ==== fmp-revision-history
 

--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricher.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.enricher.fabric8;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.maven.core.config.PlatformMode;
+import io.fabric8.maven.enricher.api.MavenEnricherContext;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import io.fabric8.maven.core.util.Configs;
+import io.fabric8.maven.docker.util.Logger;
+import io.fabric8.maven.enricher.api.BaseEnricher;
+
+public class ServiceDiscoveryEnricher extends BaseEnricher {
+    static final String ENRICHER_NAME        = "f8-service-discovery";
+
+    //Default Prefix
+    static final String PREFIX    = "discovery.3scale.net/";
+    //Service Annotations
+    static final String DISCOVERY_VERSION = "discovery-version";
+    static final String SCHEME            = "scheme";
+    static final String PATH              = "path";
+    static final String DESCRIPTION_PATH  = "description-path";
+    //Service Labels
+    static final String DISCOVERABLE      = "discoverable";
+
+    private File springConfigDir;
+    private String path             = null;
+    private String scheme           = "http";
+    private String descriptionPath  = null;
+    private String discoverable     = null;
+    private String discoveryVersion = "v1";
+
+    private enum Config implements Configs.Key {
+        descriptionPath,
+        discoverable,
+        discoveryVersion,
+        path,
+        scheme,
+        springDir;
+
+        public String def() { return d; } protected String d;
+    }
+    
+    public ServiceDiscoveryEnricher(MavenEnricherContext buildContext) {
+        super(buildContext, ENRICHER_NAME);
+
+        File baseDir = getContext().getProjectDirectory();
+        springConfigDir = new File(getConfig(Config.springDir, baseDir + "/src/main/resources/spring"));
+        discoverable    = getConfig(Config.discoverable, null);
+    }
+
+    @Override
+    public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
+        builder.accept(new TypedVisitor<ServiceBuilder>() {
+            @Override
+            public void visit(ServiceBuilder serviceBuilder) {
+                tryCamelDSLProject();
+                if (discoverable != null) {
+                    Map<String, String> annotations = new HashMap<>();
+                    annotations.put(PREFIX + DISCOVERY_VERSION, getConfig(Config.discoveryVersion, discoveryVersion));
+                    annotations.put(PREFIX + SCHEME, getConfig(Config.scheme, scheme));
+                    if (getConfig(Config.path, path) != null) {
+                        annotations.put(PREFIX + PATH, getConfig(Config.path, path));
+                    }
+                    if (getConfig(Config.descriptionPath, descriptionPath) != null) {
+                        annotations.put(PREFIX + DESCRIPTION_PATH, getConfig(Config.descriptionPath, descriptionPath));
+                    }
+                    if (log.isVerboseEnabled()) {
+                        for (String annotationName : annotations.keySet()) {
+                            log.verbose(Logger.LogVerboseCategory.BUILD, "Add %s annotation: %s=%s", PREFIX,
+                                    annotationName, annotations.get(annotationName));
+                        }
+                    }
+
+                    Map<String, String> labels = new HashMap<>();
+                    String labelName = PREFIX + DISCOVERABLE;
+                    labels.put(labelName, getConfig(Config.discoverable, discoverable));
+                    if (log.isVerboseEnabled()) {
+                        log.verbose(Logger.LogVerboseCategory.BUILD, "Add %s label: %s=%s", PREFIX,
+                                labelName, labels.get(labelName));
+                    }
+
+                    serviceBuilder.editMetadata()
+                            .addToAnnotations(annotations)
+                            .addToLabels(labels)
+                            .endMetadata();
+                }
+            }
+        });
+    }
+
+    public void tryCamelDSLProject() {
+        File camelContextXmlFile = new File(springConfigDir.getAbsoluteFile() + "/camel-context.xml");
+        if (camelContextXmlFile.exists()) {
+            try {
+                Document doc = DocumentBuilderFactory.newInstance()
+                        .newDocumentBuilder().parse(camelContextXmlFile);
+                XPath xPath = XPathFactory.newInstance().newXPath();
+                Node nl = (Node) xPath.evaluate(
+                        "/beans/camelContext/restConfiguration",
+                        doc,
+                        XPathConstants.NODE);
+                if (nl != null) {
+                    discoverable = "true";
+                    if (nl.getAttributes().getNamedItem("scheme")!=null) {
+                        scheme = nl.getAttributes().getNamedItem("scheme").getNodeValue();
+                    }
+                    if (nl.getAttributes().getNamedItem("contextPath")!=null) {
+                        path = nl.getAttributes().getNamedItem("contextPath").getNodeValue();
+                    }
+                    if (nl.getAttributes().getNamedItem("apiContextPath")!=null) {
+                        descriptionPath = nl.getAttributes().getNamedItem("apiContextPath").getNodeValue();
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Failed to load camel context file: %s", e);
+            }
+        }
+    }
+
+}

--- a/enricher/fabric8/src/main/resources/META-INF/fabric8/enricher-default
+++ b/enricher/fabric8/src/main/resources/META-INF/fabric8/enricher-default
@@ -19,3 +19,4 @@ io.fabric8.maven.enricher.fabric8.DockerHealthCheckEnricher,510
 
 # Other enrichers
 io.fabric8.maven.enricher.fabric8.PrometheusEnricher
+io.fabric8.maven.enricher.fabric8.ServiceDiscoveryEnricher

--- a/enricher/fabric8/src/test/resources/spring/camel-context.xml
+++ b/enricher/fabric8/src/test/resources/spring/camel-context.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring       http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+
+        <onException>
+            <exception>java.lang.Exception</exception>
+            <handled><constant>true</constant></handled>
+            <setHeader headerName="Exchange.HTTP_RESPONSE_CODE">
+                <constant>500</constant>
+            </setHeader>
+            <setBody>
+                <simple>My Exception Message</simple>
+            </setBody>
+        </onException>
+
+        <restConfiguration component="servlet" scheme="https"
+              contextPath="myapi" apiContextPath="myapi/openapi.json"/>
+
+        <rest path="/openapi.json" enableCORS="true">
+            <get id="openapi.json" produces="application/json" uri="openapi.json">
+                <description>Gets the openapi document for this service</description>
+                <route>
+                    <setBody>
+                        <simple>resource:classpath:openapi.json</simple>
+                    </setBody>
+                </route>
+            </get>
+        </rest>
+
+        <route>
+            <from uri="{{.}}"/>
+            <to uri="direct:501"/>
+        </route>
+
+        <route>
+            <from uri="direct:501"/>
+            <log message="API operation not yet implemented: GET /"/>
+            <setHeader headerName="Exchange.HTTP_RESPONSE_CODE">
+                <constant>501</constant>
+            </setHeader>
+            <setBody><simple>API operation not implemented: GET /</simple></setBody>
+        </route>
+
+    </camelContext>
+</beans>

--- a/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
+++ b/plugin/src/main/resources/META-INF/fabric8/profiles-default.yml
@@ -62,6 +62,7 @@
     - f8-healthcheck-docker
     - f8-healthcheck-webapp
     - f8-prometheus
+    - f8-service-discovery
     # Dependencies shouldn't be enriched anymore, therefor it's last in the list
     - fmp-dependency
     - fmp-revision-history


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-15034

A port of https://github.com/jboss-fuse/fabric8-maven-plugin/commit/a346bb1dacd96fa8e2d754ccb60814916440a439 changed for 4.3.x API. I had to remove the test case because the test dependencies changed over time and FMP is deprecated after all.

I'll provide similar port for JKube.