### PR TITLE
ENTESB-12238: [SB2] Quickstarts arquillian test fail - Generated IS h…

### DIFF
--- a/core/src/main/java/io/fabric8/maven/core/service/openshift/ImageStreamService.java
+++ b/core/src/main/java/io/fabric8/maven/core/service/openshift/ImageStreamService.java
@@ -86,6 +86,7 @@ public class ImageStreamService {
                     .endMetadata()
 
                     .withNewSpec()
+                    .withNewLookupPolicy(true)
                     .addNewTag()
                       .withName(tag)
                       .withNewFrom().withKind("ImageStreamImage").endFrom()

--- a/core/src/test/java/io/fabric8/maven/core/service/openshift/ImageStreamServiceTest.java
+++ b/core/src/test/java/io/fabric8/maven/core/service/openshift/ImageStreamServiceTest.java
@@ -88,6 +88,9 @@ public class ImageStreamServiceTest {
         assertEquals("ImageStream", isRead.get("kind"));
         Map spec = (Map<String, Object>) isRead.get("spec");
         assertNotNull(spec);
+        Map lookupPolicy = (Map<String, Object>) spec.get("lookupPolicy");
+        assertNotNull(lookupPolicy);
+        assertTrue((Boolean) lookupPolicy.get("local"));
         List tags = (List) spec.get("tags");
         assertNotNull(tags);
         assertEquals(1,tags.size());


### PR DESCRIPTION
…as now a local Lookup Policy