### PR TITLE
[ENTESB-15034](fix 2) Missing labels on Openshift Service Object in FMP quickstart spring-boot-camel-rest-3scale

### DIFF
--- a/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricher.java
+++ b/enricher/fabric8/src/main/java/io/fabric8/maven/enricher/fabric8/ServiceDiscoveryEnricher.java
@@ -99,7 +99,7 @@ public class ServiceDiscoveryEnricher extends BaseEnricher {
                     }
 
                     Map<String, String> labels = new HashMap<>();
-                    String labelName = PREFIX + DISCOVERABLE;
+                    String labelName = PREFIX.substring(0, PREFIX.length() - 1);
                     labels.put(labelName, getConfig(Config.discoverable, discoverable));
                     if (log.isVerboseEnabled()) {
                         log.verbose(Logger.LogVerboseCategory.BUILD, "Add %s label: %s=%s", PREFIX,


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-15034